### PR TITLE
Fix paper_examples functions _dyck1_ptf and dyckk_ptf

### DIFF
--- a/paper_examples.rasp
+++ b/paper_examples.rasp
@@ -51,8 +51,8 @@ sort_by_most_freq = _sort_by_freq_bos("§",300);
 
 def _dyck1_ptf() {
 	up_to_self = select(indices,indices,<=);
-	n_opens = (indices+1)*aggregate(up_to_self,indicator(tokens_str=="("));
-	n_closes = (indices+1)*aggregate(up_to_self,indicator(tokens_str==")"));
+	n_opens = round((indices+1)*aggregate(up_to_self,indicator(tokens_str=="(")));
+	n_closes = round((indices+1)*aggregate(up_to_self,indicator(tokens_str==")")));
 	balance = n_opens - n_closes;
 	prev_imbalances = aggregate(up_to_self,indicator(balance<0));
 	return "F" if prev_imbalances>0 else 
@@ -68,8 +68,8 @@ def dyckk_ptf(paren_pairs) {
 	opens = indicator(tokens_str in openers);
 	closes = indicator(tokens_str in closers);
 	up_to_self = select(indices,indices,<=);
-	n_opens = (indices+1)*aggregate(up_to_self,opens);
-	n_closes = (indices+1)*aggregate(up_to_self,closes);
+	n_opens = round((indices+1)*aggregate(up_to_self,opens));
+	n_closes = round((indices+1)*aggregate(up_to_self,closes));
 	depth = n_opens - n_closes;
 	delay_closer = depth + closes;
 	depth_index = selector_width(select(delay_closer,delay_closer,==) and up_to_self);

--- a/tests/tgt/paper_examples.txt
+++ b/tests/tgt/paper_examples.txt
@@ -20,7 +20,7 @@ running example is: hello
 >> 	 =  [0, 2, 1, 2, 1, 2, 2, 4, 2, 1, 1, 1, 4, 1, 4, 1, 1, 1, 1, 1, 1, 2, 1, 4, 1, 1] (ints)
 >> 	 =  [§, d, v, s, l, m, a, n, ,, k, x, §, §, §, §, §, §, §, §, §, §, §, §, §, §, §, §, §, §, §] (strings)
 >> 	 =  [P, T, P, P, P, P, P, T, P, P, P, P, P, P, P, P, P, P, P, P, P, P, P, T, P, P, P, P, P, P, P, P, P, P, P, P, P, P, P, P, P, T, F, F, F, F, F, F, F, F] (strings)
->> 	 =  [P, P, P, P, P, P, P, P, P, P, P, P, P, P, P, P, P, P, P, P, P, T, P, P, P, P, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F] (strings)
+>> 	 =  [P, P, P, P, P, P, P, P, P, P, P, P, P, P, P, P, P, P, P, P, P, T, P, P, P, P, P, P, P, P, P, P, P, T, P, T, P, T, P, T, P, P, P, P, P, P, P, P, P, P, P, P, P, T, P, F, F, F, F] (strings)
 >> 	 =  [P, T, P, T, P, T, P, P, P, P, P, P, P, P, P, T, P, P, P, T, P, P, P, T, P, T, P, T, P, F, F, F, F, F, F, F, F, F, F, F, F, F, F] (strings)
 >> .. .. .. 
 


### PR DESCRIPTION
In rare cases, `dyckk_ptf` returns incorrect results due to floating point inaccuracies. Example to reproduce:
```
>> load "paper_examples";
     s-op: hist_bos
     s-op: hist_nobos
     s-op: reverse
     s-op: sort_bos
     s-op: hist2_bos
     s-op: sort_by_most_freq
     s-op: dyck1_ptf
     paper_examples function: dyckk_ptf(paren_pairs)
     s-op: dyck2_ptf
     s-op: dyck3_ptf
>> dyck2_ptf("{(){}{(){}}()}({}({}()){}()){}{}");
	 =  [P, P, P, P, P, P, P, P, P, P, P, P, P, T, P, P, P, P, P, P, P, P, P, P, P, P, P, T, P, F, F, F] (strings)
```

```
input:    {(){}{(){}}()}({}({}()){}()){}{}
output:   PPPPPPPPPPPPPTPPPPPPPPPPPPPTPFFF
expected: PPPPPPPPPPPPPTPPPPPPPPPPPPPTPTPT 
                                       ^ this is where the error happens
```
I fixed this by rounding two intermediate results that are supposed to be integers. Just to be sure, I applied the same fix to `_dyck1_ptf`, although I wasn't able to trigger the error there.