### PR TITLE
Add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+raspenv
+__pycache__


### PR DESCRIPTION
Virtual environments and `__pycache__` directories are typically excluded from version control systems in Python projects. This pull request adds a gitignore file that instructs Git to exclude the virtual environment created by `setup.sh` and any `__pycache__` directories.