### PR TITLE
Add syntax highlighting for Vim

### DIFF
--- a/syntax_highlighting/README.md
+++ b/syntax_highlighting/README.md
@@ -3,6 +3,24 @@
 #### Emacs
 Arthur Amalvy has created an Emacs major mode for RASP, which can be found (along with installation instructions) here: https://gitlab.com/Aethor/rasp-mode . Thank you!
 
+#### Vim
+
+The Vim syntax file for RASP is provided in this directory. It can be installed as follows.
+
+1. Place `rasp.vim` in the `syntax` sub-directory of your Vim or Neovim configuration directory.
+2. Add the following Vimscript or Lua automatic command to your configuration file to set the RASP file type.
+
+```Vimscript
+autocmd BufNewFile,BufRead *.rasp set filetype=rasp
+```
+
+```Lua
+vim.api.nvim_create_autocmd({ 'BufRead', 'BufNewFile' }, {
+    pattern = { "*.rasp" },
+    command = 'set filetype=rasp'
+})
+```
+
 #### Sublime
 For the Sublime Text editor, you can get syntax highlighting for `.rasp` files as follows:
 1. Install package control for Sublime (you might already have it: look in the menu [Sublime Text]->[Preferences] and see if it's there. If not, follow the instructions at https://packagecontrol.io/installation).

--- a/syntax_highlighting/rasp.vim
+++ b/syntax_highlighting/rasp.vim
@@ -1,0 +1,45 @@
+" Vim syntax file
+" Language: RASP
+" Maintainer: Emile Ferreira
+" Latest revision: 26 April 2023
+
+if exists("b:current_syntax")
+    finish
+endif
+let b:current_syntax = "rasp"
+
+syn keyword raspConstOps        indices length tokens
+syn keyword raspConstConvert    tokens_str tokens_int tokens_bool tokens_float
+syn keyword raspConstBool       True False
+syn keyword raspControl         if else for in return
+syn keyword raspDef             def
+syn keyword raspBase            select aggregate selector_width
+syn keyword raspLists           zip range len
+syn keyword raspElementwise     round indicator
+syn keyword raspArithmeticOp    - \+ \* / \^ %
+syn keyword raspAssignmentOp    =
+syn keyword raspComparisonOp    == != >= <= > <
+syn keyword raspLogicalOp       and or not
+syn match   raspNumber          "-\?\d\+\(\.\d\+\)\?"
+syn match   raspIdentifier      "\<[a-zA-Z_][a-zA-Z0-9_]*\>"
+syn match   raspFunction        /\<[a-zA-Z_][a-zA-Z0-9_]*\s*(/me=e-1,he=e-1
+syn match   raspComment         "#.*$"
+syn region  raspString matchgroup=raspString start=+"+ skip=+\\.+ end=+"+
+
+hi def link raspConstOps        Constant
+hi def link raspConstConvert    Constant
+hi def link raspConstBool       Boolean
+hi def link raspControl         Conditional
+hi def link raspDef             Statement
+hi def link raspBase            Function
+hi def link raspLists           Function
+hi def link raspElementwise     Function
+hi def link raspArithmeticOp    Operator
+hi def link raspAssignmentOp    Operator
+hi def link raspComparisonOp    Operator
+hi def link raspLogicalOp       Operator
+hi def link raspNumber          Number
+hi def link raspIdentifier      Identifier
+hi def link raspFunction        Function
+hi def link raspComment         Comment
+hi def link raspString          String


### PR DESCRIPTION
I've followed [RASP.sublime-syntax](syntax_highlighting/RASP.sublime-syntax) faithfully (mostly) in creating a Vim syntax file for RASP. The filename is lowercase as is Vim syntax file convention. I hope that others find this useful.