### PR TITLE
Add other Linux package managers to setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -14,8 +14,19 @@ if [ "$(uname)" == "Darwin" ]; then
 		HOMEBREW_NO_AUTO_UPDATE=1 brew install rlwrap
 	fi
 elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
-	sudo apt-get install graphviz
-	sudo apt-get install rlwrap
+	if which apt-get > /dev/null 2>&1; then
+		sudo apt-get install graphviz rlwrap
+	elif which pacman > /dev/null 2>&1; then
+		sudo pacman -S --needed graphviz rlwrap
+	elif which dnf > /dev/null 2>&1; then
+		sudo dnf install graphviz rlwrap
+	elif which emerge > /dev/null 2>&1; then
+		sudo emerge --ask media-gfx/graphviz app-misc/rlwrap
+	else
+		echo "Attempted to install graphviz and rlwrap, but your package manager is not supported by this script. Consider installing them manually:"
+		echo $rlwrap_desc
+		echo $graphviz_desc
+	fi
 else
 	echo "For the best experience, you should install graphviz and rlwrap."
 	echo "I'm sorry, I don't know how to do this on your OS (please email me with OS+directions if you do, so I can update!)"


### PR DESCRIPTION
I've added support for the package managers of some of the most popular Linux distributions (Ubuntu, Arch, Fedora and Gentoo) to the setup script. I've also added an error message to display if none of these are available. I use Arch, BTW ;)