### PR TITLE
Draw trivial tokens and indices

### DIFF
--- a/RASP_support/DrawCompFlow.py
+++ b/RASP_support/DrawCompFlow.py
@@ -464,11 +464,12 @@ class Layer:
 			ff_parents += ff.get_nonminor_parent_sequences()
 		ff_parents = list(set(ff_parents))
 		ff_parents = [p for p in ff_parents if not guarded_contains(d_ffs, p)]
-		# in the trivial case (no parents and only one ff), the ff is marked as
-		# constant and should be labelled as 'X'
+		# in the trivial case (no parents and only one ff), the ff is
+		# temporarily marked as constant and should be labelled as 'X'
 		for x in [ff for ff in d_ffs if ff.is_constant()]:
 			d_ffs.remove(x)
 			ff_parents.append(x)
+			x._constant = False
 		rows_by_type = {RES: d_ffs, VVAR: ff_parents}
 		rowtype_order = [VVAR, RES]
 		if add_tokens_on_ff and not contains_tokens(ff_parents):

--- a/RASP_support/DrawCompFlow.py
+++ b/RASP_support/DrawCompFlow.py
@@ -387,6 +387,8 @@ class Layer:
 			ff_parents += ff.get_nonminor_parent_sequences()
 		ff_parents = list(set(ff_parents))
 		ff_parents = [p for p in ff_parents if not guarded_contains(d_ffs,p)]
+		if not ff_parents and len(d_ffs) == 1 and d_ffs[0]._constant:
+			ff_parents, d_ffs = d_ffs, ff_parents
 		rows_by_type = {RES:d_ffs,VVAR:ff_parents}
 		rowtype_order = [VVAR,RES]
 		if add_tokens_on_ff and not contains_tokens(ff_parents):

--- a/RASP_support/DrawCompFlow.py
+++ b/RASP_support/DrawCompFlow.py
@@ -465,10 +465,10 @@ class Layer:
 		ff_parents = list(set(ff_parents))
 		ff_parents = [p for p in ff_parents if not guarded_contains(d_ffs, p)]
 		# in the trivial case (no parents and only one ff), the ff is marked as
-		# constant
-		if not ff_parents and len(d_ffs) == 1 and d_ffs[0]._constant:
-			# switch the parents and ffs to label the trivial ff as 'X'
-			ff_parents, d_ffs = d_ffs, ff_parents
+		# constant and should be labelled as 'X'
+		for x in [ff for ff in d_ffs if ff.is_constant()]:
+			d_ffs.remove(x)
+			ff_parents.append(x)
 		rows_by_type = {RES: d_ffs, VVAR: ff_parents}
 		rowtype_order = [VVAR, RES]
 		if add_tokens_on_ff and not contains_tokens(ff_parents):

--- a/RASP_support/DrawCompFlow.py
+++ b/RASP_support/DrawCompFlow.py
@@ -464,7 +464,10 @@ class Layer:
 			ff_parents += ff.get_nonminor_parent_sequences()
 		ff_parents = list(set(ff_parents))
 		ff_parents = [p for p in ff_parents if not guarded_contains(d_ffs, p)]
+		# in the trivial case (no parents and only one ff), the ff is marked as
+		# constant
 		if not ff_parents and len(d_ffs) == 1 and d_ffs[0]._constant:
+			# switch the parents and ffs to label the trivial ff as 'X'
 			ff_parents, d_ffs = d_ffs, ff_parents
 		rows_by_type = {RES: d_ffs, VVAR: ff_parents}
 		rowtype_order = [VVAR, RES]

--- a/RASP_support/analyse.py
+++ b/RASP_support/analyse.py
@@ -185,10 +185,6 @@ def get_all_ancestor_heads_and_ffs(self, remove_minors=False):
 	if len(all_ffs) > 1:
 		# filter out non-ffs in the non-trivial case
 		all_ffs = [m for m in all_ffs if m.from_zipmap]
-	else:
-		# temporarily mark the sequence as constant in the trivial case
-		for ff in all_ffs:
-			ff.mark_as_constant()
 	if remove_minors:
 		all_ffs = [ff for ff in all_ffs if not ff.is_minor]
 

--- a/RASP_support/analyse.py
+++ b/RASP_support/analyse.py
@@ -186,9 +186,9 @@ def get_all_ancestor_heads_and_ffs(self, remove_minors=False):
 		# filter out non-ffs in the non-trivial case
 		all_ffs = [m for m in all_ffs if m.from_zipmap]
 	else:
-		# mark the sequence as constant (indices / tokens) in the trivial case
+		# mark the sequence as constant in the case of trivial indices or tokens
 		for ff in all_ffs:
-			ff._constant = True
+			ff.mark_as_constant()
 	if remove_minors:
 		all_ffs = [ff for ff in all_ffs if not ff.is_minor]
 

--- a/RASP_support/analyse.py
+++ b/RASP_support/analyse.py
@@ -157,7 +157,9 @@ def get_all_ancestor_heads_and_ffs(self,remove_minors=False):
 			self.select = select
 	seq_layers, layer_selects = self.schedule('best',remove_minors=remove_minors)
 
-	all_ffs = [m for m in self.get_full_seq_parents() if m.from_zipmap]
+	all_ffs = self.get_full_seq_parents()
+	if len(all_ffs) > 1:
+		all_ffs = [m for m in all_ffs if m.from_zipmap]
 	if remove_minors:
 		all_ffs = [ff for ff in all_ffs if not ff.is_minor]
 

--- a/RASP_support/analyse.py
+++ b/RASP_support/analyse.py
@@ -186,7 +186,7 @@ def get_all_ancestor_heads_and_ffs(self, remove_minors=False):
 		# filter out non-ffs in the non-trivial case
 		all_ffs = [m for m in all_ffs if m.from_zipmap]
 	else:
-		# mark the sequence as constant in the case of trivial indices or tokens
+		# temporarily mark the sequence as constant in the trivial case
 		for ff in all_ffs:
 			ff.mark_as_constant()
 	if remove_minors:

--- a/RASP_support/analyse.py
+++ b/RASP_support/analyse.py
@@ -160,6 +160,9 @@ def get_all_ancestor_heads_and_ffs(self,remove_minors=False):
 	all_ffs = self.get_full_seq_parents()
 	if len(all_ffs) > 1:
 		all_ffs = [m for m in all_ffs if m.from_zipmap]
+	else:
+		for ff in all_ffs:
+			ff._constant = True
 	if remove_minors:
 		all_ffs = [ff for ff in all_ffs if not ff.is_minor]
 

--- a/RASP_support/analyse.py
+++ b/RASP_support/analyse.py
@@ -183,8 +183,10 @@ def get_all_ancestor_heads_and_ffs(self, remove_minors=False):
 
 	all_ffs = self.get_full_seq_parents()
 	if len(all_ffs) > 1:
+		# filter out non-ffs in the non-trivial case
 		all_ffs = [m for m in all_ffs if m.from_zipmap]
 	else:
+		# mark the sequence as constant (indices / tokens) in the trivial case
 		for ff in all_ffs:
 			ff._constant = True
 	if remove_minors:


### PR DESCRIPTION
Presently, drawing tokens or indices by themselves (for example, `draw(tokens)` or `draw(indices, "hello")`) results in an empty figure. This adds support for drawing trivial tokens and indices, as feedforward layers.